### PR TITLE
When dest path not exists, create path file.

### DIFF
--- a/copy-file-on-save.el
+++ b/copy-file-on-save.el
@@ -125,9 +125,13 @@
 
 (defun copy-file-on-save--copy-file ()
   "Copy a file using `copy-file'."
-  (let ((from-path buffer-file-name)
-        (to-path   (copy-file-on-save--replace-path buffer-file-name)))
-    (copy-file from-path to-path t)))
+  (let* ((from-path buffer-file-name)
+	 (to-path   (copy-file-on-save--replace-path buffer-file-name))
+	 (to-dir (file-name-directory to-path)))
+    (progn
+      (if (not (file-exists-p to-dir))
+	  (make-directory to-dir t) nil)
+      (copy-file from-path to-path t))))
 
 (defun copy-file-on-save--replace-path (src-file-path)
   "Return replace dest file path by `SRC-FILE-PATH'."


### PR DESCRIPTION
When create new file with a new directory, copy-on-save would raise 'No such file'. It's better to check and create correct path before copy to.